### PR TITLE
Remove unnecessary API call

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -87,13 +87,14 @@ class Client
         $this->addPlugin(new LxdExceptionThower());
 
         $this->setUrl($this->url);
-
-        $extensions = $this->host->info()["api_extensions"];
-        $this->hasVmsCache = in_array("virtual-machines", $extensions);
+        
     }
 
     public function hasVms()
     {
+        if (!isset($this->hasVmsCache)) {
+            $this->hasVmsCache = in_array("virtual-machines", $this->host->info()["api_extensions"]);
+        }
         return $this->hasVmsCache;
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -87,12 +87,11 @@ class Client
         $this->addPlugin(new LxdExceptionThower());
 
         $this->setUrl($this->url);
-        
     }
 
     public function hasVms()
     {
-        if (!isset($this->hasVmsCache)) {
+        if ($this->hasVmsCache === null) {
             $this->hasVmsCache = in_array("virtual-machines", $this->host->info()["api_extensions"]);
         }
         return $this->hasVmsCache;


### PR DESCRIPTION
Currently, each time the `Client` class is constructed, an API call is made to the server in order to determine the value of `$hasVmsCache`. This is unnecessary since that value is only ever used in `hasVms()`, which is respectively called at a later point.

Theoretically this may not be a huge issue as whomever is constructing the class is probably going to be issuing a request & invoking the above code anyway, but it can still be considered an anti-pattern.

One occasion where this is problematic is dependency injection - where the class is instantiated no matter if it is actually going to issue any requests or not.

In my particular case, each request to my entire application also issues a request to the LXD API server since the class is being constructed by DI, whether I use it or not.