### PR TITLE
Add the timeout parameter correctly when waiting for an operation

### DIFF
--- a/src/Endpoint/Operations.php
+++ b/src/Endpoint/Operations.php
@@ -81,7 +81,7 @@ class Operations extends AbstractEndpoint
         $endpoint = $this->getEndpoint().$uuid.'/wait';
 
         if (is_numeric($timeout) && $timeout > 0) {
-            $endpoint .= '?timeout='.$timeout;
+            $config['timeout'] = $timeout;
         }
 
         return $this->get($endpoint, $config);


### PR DESCRIPTION
Using the timeout parameter to wait() currently results in somewhat broken query ending in "/wait?timeout=30?project=default", which fails due to a parsing error on the LXD side.