### PR TITLE
PHP8, Guzzle 7 and new Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,13 @@ client.key
 .c9
 .env
 .directory
+
+# IDE & System
+.DS_Store
+/.idea
+/.vscode
+.phpstorm.meta.php
+.phpunit.result.cache
+Thumbs.db
+/*.iml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 sudo: false
 php:
-    - 5.5
-    - 5.6
-    - 7.0
+    - 7.3
+    - 7.4
+    - 8.0
+    - 8.1
 cache:
   directories:
     - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Via Composer
 $ composer require dhope0000/lxd
 ```
 
+For usage of this library any httpclient library is needed. If you don't already use one in your project, please install one in advance.
+
+``` bash
+$ composer require php-http/guzzle7-adapter
+```
+
+## Install for usage with Guzzle 6
+
+``` bash
+$ composer require php-http/guzzle6-adapter
+$ composer require dhope0000/lxd "^0.24"
+```
+
 ## Usage
 
 See the [`docs`](./docs) for more information.

--- a/composer.json
+++ b/composer.json
@@ -27,16 +27,16 @@
     "require": {
         "php": "~5.5|~7.0",
         "psr/http-message": "^1.0",
-        "php-http/httplug": "^1.0",
-        "php-http/discovery": "^1.0",
+        "php-http/httplug": "^2.2",
+        "php-http/discovery": "^1.12",
         "php-http/client-implementation": "^1.0",
-        "php-http/client-common": "^1.1",
+        "php-http/client-common": "^2.3",
         "php-http/cache-plugin": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
         "mockery/mockery": "^0.9.5",
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.2",
         "php-http/mock-client": "^0.3",
         "squizlabs/php_codesniffer": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "~5.5|~7.0",
+        "php": "^7.3 || ^8.0",
         "psr/http-message": "^1.0",
         "php-http/httplug": "^2.2",
         "php-http/discovery": "^1.12",

--- a/src/Endpoint/InstaceBase.php
+++ b/src/Endpoint/InstaceBase.php
@@ -604,7 +604,7 @@ abstract class InstaceBase extends AbstractEndpoint
             $waitResponse = $this->client->operations->wait($response['id']);
 
             if ($record === true) {
-                $output = $waitResponse['metadata']['output'];
+                $output = isset($waitResponse['metadata']['output']) ? $waitResponse['metadata']['output'] : [];
                 $return = $waitResponse['metadata']['return'];
                 unset($waitResponse);
                 $response = [];

--- a/src/Endpoint/InstaceBase.php
+++ b/src/Endpoint/InstaceBase.php
@@ -573,7 +573,7 @@ abstract class InstaceBase extends AbstractEndpoint
      * @param bool         $record      Whether to store stdout and stderr
      * @param array        $environment An associative array, the key will be the environment variable name
      * @param bool         $wait        Wait for operation to finish
-     * @return object
+     * @return array|string
      */
     public function execute($name, $command, $record = false, array $environment = [], $wait = false)
     {
@@ -601,21 +601,24 @@ abstract class InstaceBase extends AbstractEndpoint
         $response = $this->post($this->getEndpoint().$name.'/exec', $opts, $config);
 
         if ($wait) {
-            $response = $this->client->operations->wait($response['id']);
-            $logs = [];
-            $output = $response['metadata']['output'];
-            $return = $response['metadata']['return'];
-            unset($response);
+            $waitResponse = $this->client->operations->wait($response['id']);
 
-            foreach ($output as $log) {
-                $response['output'][] = str_replace(
-                    '/'.$this->client->getApiVersion().$this->getEndpoint().$name.'/logs/',
-                    '',
-                    $log
-                );
+            if ($record === true) {
+                $output = $waitResponse['metadata']['output'];
+                $return = $waitResponse['metadata']['return'];
+                unset($waitResponse);
+                $response = [];
+
+                foreach ($output as $log) {
+                    $response['output'][] = str_replace(
+                        '/' . $this->client->getApiVersion() . $this->getEndpoint() . $name . '/logs/',
+                        '',
+                        $log
+                    );
+                }
+
+                $response['return'] = $return;
             }
-
-            $response['return'] = $return;
         }
 
         return $response;

--- a/src/Endpoint/Instance/Logs.php
+++ b/src/Endpoint/Instance/Logs.php
@@ -3,6 +3,7 @@
 namespace Opensaucesystems\Lxd\Endpoint\Instance;
 
 use Opensaucesystems\Lxd\Endpoint\AbstractEndpoint;
+use Opensaucesystems\Lxd\Exception\InvalidEndpointException;
 
 class Logs extends AbstractEndpoint
 {
@@ -61,5 +62,21 @@ class Logs extends AbstractEndpoint
     public function remove($name, $log)
     {
         return $this->delete($this->getEndpoint().$name.'/logs/'.$log);
+    }
+
+    public function __get($endpoint)
+    {
+        $className =  basename(str_replace('\\', '/', get_class($this)));
+        $class = __NAMESPACE__.'\\'.$className.'\\'.ucfirst($endpoint);
+
+        if (class_exists($class)) {
+            $class = new $class($this->client);
+            $class->setEndpoint($this->getEndpoint());
+            return $class;
+        } else {
+            throw new InvalidEndpointException(
+                'Endpoint '.$class.', not implemented.'
+            );
+        }
     }
 }

--- a/src/Endpoint/Instance/Logs.php
+++ b/src/Endpoint/Instance/Logs.php
@@ -4,6 +4,7 @@ namespace Opensaucesystems\Lxd\Endpoint\Instance;
 
 use Opensaucesystems\Lxd\Endpoint\AbstractEndpoint;
 use Opensaucesystems\Lxd\Exception\InvalidEndpointException;
+use Opensaucesystems\Lxd\Helpers\Str;
 
 class Logs extends AbstractEndpoint
 {
@@ -67,7 +68,7 @@ class Logs extends AbstractEndpoint
     public function __get($endpoint)
     {
         $className =  basename(str_replace('\\', '/', get_class($this)));
-        $class = __NAMESPACE__.'\\'.$className.'\\'.ucfirst($endpoint);
+        $class = __NAMESPACE__.'\\'.$className.'\\'.Str::studly($endpoint);
 
         if (class_exists($class)) {
             $class = new $class($this->client);

--- a/src/Endpoint/Instance/Logs/ExecOutput.php
+++ b/src/Endpoint/Instance/Logs/ExecOutput.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Opensaucesystems\Lxd\Endpoint\Instance\Logs;
+
+use Opensaucesystems\Lxd\Endpoint\AbstractEndpoint;
+
+class ExecOutput extends AbstractEndpoint
+{
+    private $endpoint;
+
+    protected function getEndpoint()
+    {
+        return $this->endpoint;
+    }
+
+    public function setEndpoint(string $endpoint)
+    {
+        $this->endpoint = $endpoint;
+    }
+
+    /**
+     * List of exec record-output logs for a container
+     *
+     * @param  string $name Name of container
+     * @return array
+     */
+    public function all($name)
+    {
+        $logs = [];
+
+        foreach ($this->get($this->getEndpoint().$name.'/logs/exec-output/') as $log) {
+            $logs[] = str_replace(
+                '/'.$this->client->getApiVersion().$this->getEndpoint().$name.'/logs/exec-output/',
+                '',
+                $log
+            );
+        }
+
+        return $logs;
+    }
+
+    /**
+     * Get the contents of a particular exec record-output log file
+     *
+     * @param string $name  Name of container
+     * @param string $log   Name of log
+     * @return object
+     */
+    public function read($name, $log)
+    {
+        return $this->get($this->getEndpoint().$name.'/logs/exec-output/'.$log);
+    }
+
+    /**
+     * Remove a particular exec record-output log file
+     *
+     * @param string $name  Name of container
+     * @param string $log   Name of log
+     * @return object
+     */
+    public function remove($name, $log)
+    {
+        return $this->delete($this->getEndpoint().$name.'/logs/exec-output/'.$log);
+    }
+}

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Opensaucesystems\Lxd\Helpers;
+
+/**
+ * Inspired by Laravel
+ * https://github.com/illuminate/support/blob/master/Str.php
+ */
+class Str
+{
+    /**
+     * The cache of studly-cased words.
+     *
+     * @var array
+     */
+    protected static $studlyCache = [];
+
+    /**
+     * Convert a value to studly caps case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function studly($value)
+    {
+        $key = $value;
+
+        if (isset(static::$studlyCache[$key])) {
+            return static::$studlyCache[$key];
+        }
+
+        $words = explode(' ', static::replace(['-', '_'], ' ', $value));
+
+        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
+
+        return static::$studlyCache[$key] = implode($studlyWords);
+    }
+}

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -29,9 +29,9 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = explode(' ', static::replace(['-', '_'], ' ', $value));
+        $words = explode(' ', str_replace(['-', '_'], ' ', $value));
 
-        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(function ($word) { return ucfirst($word); }, $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }

--- a/src/HttpClient/Plugin/LxdExceptionThower.php
+++ b/src/HttpClient/Plugin/LxdExceptionThower.php
@@ -3,6 +3,7 @@
 namespace Opensaucesystems\Lxd\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Http\Client\Exception\HttpException;
@@ -21,7 +22,7 @@ class LxdExceptionThower implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $promise = $next($request);
 

--- a/src/HttpClient/Plugin/PathPrepend.php
+++ b/src/HttpClient/Plugin/PathPrepend.php
@@ -3,6 +3,7 @@
 namespace Opensaucesystems\Lxd\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -25,7 +26,7 @@ class PathPrepend implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $currentPath = $request->getUri()->getPath();
         $uri = $request->getUri()->withPath($this->path.$currentPath);

--- a/src/HttpClient/Plugin/PathTrimEnd.php
+++ b/src/HttpClient/Plugin/PathTrimEnd.php
@@ -2,6 +2,7 @@
 namespace Opensaucesystems\Lxd\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -23,7 +24,7 @@ class PathTrimEnd implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $trimPath = rtrim($request->getUri()->getPath(), $this->trim);
         $uri = $request->getUri()->withPath($trimPath);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,10 +4,11 @@ namespace Opensaucesystems\Lxd\Tests;
 
 use Mockery;
 use Opensaucesystems\Lxd\Client;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -66,16 +67,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($url, $client->getUrl());
     }
 
-    /**
-     * Test that endpoint doesn't exist
-     *
-     * @expectedException \Opensaucesystems\Lxd\Exception\InvalidEndpointException
-     */
     public function testInvalidEndpointException()
     {
         $httpClient = Mockery::mock('\Http\Client\HttpClient');
 
         $client = new Client($httpClient);
+
+        $this->expectException(\Opensaucesystems\Lxd\Exception\InvalidEndpointException::class);
 
         $client->nonEndpoint;
     }

--- a/tests/Endpoint/ImagesTest.php
+++ b/tests/Endpoint/ImagesTest.php
@@ -359,12 +359,6 @@ class ImagesTest extends TestCase
         $this->assertEquals($expectedValue, $endpoint->createFromRemote($server, $options, $autoUpdate, $wait));
     }
 
-    /**
-     * Test creating
-     *
-     * @expectedException        Exception
-     * @expectedExceptionMessage Invalid protocol.  Valid choices: lxd, simplestreams
-     */
     public function testCreateFromRemoteWithIncorrectProtocol()
     {
         $server = "https://images.linuxcontainers.org:8443";
@@ -380,15 +374,12 @@ class ImagesTest extends TestCase
 
         $endpoint = $this->getEndpointMock($this->getEndpointClass());
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid protocol.  Valid choices: lxd, simplestreams');
+
         $endpoint->createFromRemote($server, $options, $autoUpdate, $wait);
     }
 
-    /**
-     * Test creating
-     *
-     * @expectedException        Exception
-     * @expectedExceptionMessage Alias or Fingerprint must be set
-     */
     public function testCreateFromRemoteWithNoAliasOrFingerprint()
     {
         $server = "https://images.linuxcontainers.org:8443";
@@ -399,6 +390,9 @@ class ImagesTest extends TestCase
         $wait = false;
 
         $endpoint = $this->getEndpointMock($this->getEndpointClass());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Alias or Fingerprint must be set');
 
         $endpoint->createFromRemote($server, $options, $autoUpdate, $wait);
     }
@@ -611,12 +605,11 @@ class ImagesTest extends TestCase
         $this->assertEquals([], $endpoint->remove($fingerprint));
     }
 
-    /**
-     * @expectedException Opensaucesystems\Lxd\Exception\InvalidEndpointException
-     */
     public function testGetEndpointDoesNotExist()
     {
         $endpoint = $this->getEndpointMock($this->getEndpointClass());
+
+        $this->expectException(\Opensaucesystems\Lxd\Exception\InvalidEndpointException::class);
 
         $endpoint->__get('invalidendpoint');
     }

--- a/tests/Endpoint/TestCase.php
+++ b/tests/Endpoint/TestCase.php
@@ -2,13 +2,15 @@
 
 namespace Opensaucesystems\Lxd\Tests\Endpoint;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as FrameworkTestCase;
+
+abstract class TestCase extends FrameworkTestCase
 {
     abstract protected function getEndpointClass();
 
     protected function getEndpointMock($endpointClass, $wait = false, $expectedValue = null)
     {
-        $httpClient = $this->getMock('Http\Client\HttpClient', ['sendRequest']);
+        $httpClient = $this->getMockBuilder('Http\Client\HttpClient')->onlyMethods(['sendRequest'])->getMock();
 
         $httpClient
             ->expects($this->any())
@@ -16,12 +18,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         if ($wait) {
             $client = $this->getMockBuilder('\Opensaucesystems\Lxd\Client')
-            ->setMethods(['__get'])
-            ->setConstructorArgs([$httpClient])
-            ->getMock();
-            
+                ->onlyMethods(['__get'])
+                ->setConstructorArgs([$httpClient])
+                ->getMock();
+
             $operations = $this->getMockBuilder('Opensaucesystems\Lxd\Endpoint\Operations')
-                ->setMethods(['wait'])
+                ->onlyMethods(['wait'])
                 ->setConstructorArgs([$client])
                 ->getMock();
 
@@ -39,7 +41,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         }
 
         return $this->getMockBuilder($endpointClass)
-            ->setMethods(['get', 'post', 'patch', 'delete', 'put'])
+            ->onlyMethods(['get', 'post', 'patch', 'delete', 'put'])
             ->setConstructorArgs([$client])
             ->getMock();
     }

--- a/tests/HttpClient/Message/ResponseMediatorTest.php
+++ b/tests/HttpClient/Message/ResponseMediatorTest.php
@@ -4,8 +4,9 @@ namespace Opensaucesystems\Lxd\Tests\HttpClient\Message;
 
 use Opensaucesystems\Lxd\HttpClient\Message\ResponseMediator;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
+class ResponseMediatorTest extends TestCase
 {
     public function testGetContent()
     {
@@ -13,7 +14,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
         $response = new Response(
             200,
             array('Content-Type'=>'application/json'),
-            \GuzzleHttp\Psr7\stream_for(json_encode($body))
+            \GuzzleHttp\Psr7\Utils::streamFor(json_encode($body))
         );
 
         $this->assertEquals($body['metadata'], ResponseMediator::getContent($response));
@@ -28,7 +29,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
         $response = new Response(
             200,
             array(),
-            \GuzzleHttp\Psr7\stream_for($body)
+            \GuzzleHttp\Psr7\Utils::streamFor($body)
         );
 
         $this->assertEquals($body, ResponseMediator::getContent($response));
@@ -43,7 +44,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
         $response = new Response(
             200,
             array('Content-Type'=>'application/json'),
-            \GuzzleHttp\Psr7\stream_for($body)
+            \GuzzleHttp\Psr7\Utils::streamFor($body)
         );
 
         $this->assertEquals($body, ResponseMediator::getContent($response));


### PR DESCRIPTION
This PR introduces support for PHP8 and Guzzle 7 adapter

Additionally it creates a new Endpoint ->logs->exec_output->
this is necessary because execute-commands that use "record"-option of output save the logs in dedicated record-output logs now. in former LxD-Versions this was all contained in logs-endpoint. But in meanwhile it is a dedicated endpoint: https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_exec-outputs_get

Until last year i contributed to the original version of ashleyhood - the PHP8 and Guzzle 7 topic was there already integrated. But since it doesn't support new endpoints and seems to be stuck on the old state, I decided to switch the fork. It would be great, if your version can do the upgrades